### PR TITLE
Don't unwrap unary records by default and add omitNothingFields option

### DIFF
--- a/src/Derive/API/TH.hs
+++ b/src/Derive/API/TH.hs
@@ -67,6 +67,7 @@ data DerivingOptions = DerivingOptions
   -- ^ Whether to snake constructors and field labels
   --   Applied after stripping prefix
   , unwrapUnaryRecords :: Bool
+  , omitNothingFields :: Bool
   , sumEncoding :: SumEncoding
   } deriving (Lift)
 
@@ -76,7 +77,8 @@ defaultDerivingOptions :: DerivingOptions
 defaultDerivingOptions = DerivingOptions
   { prefix = Nothing
   , snake = True
-  , unwrapUnaryRecords = True
+  , unwrapUnaryRecords = False
+  , omitNothingFields = False
   , sumEncoding = defaultTaggedObject }
 
 derivingOptionsToJsonOptions :: DerivingOptions -> Options
@@ -84,6 +86,7 @@ derivingOptionsToJsonOptions DerivingOptions{..} = defaultOptions
   { fieldLabelModifier = snaked . stripped
   , constructorTagModifier = snaked . stripped
   , sumEncoding
+  , omitNothingFields
   , unwrapUnaryRecords }
   where
     snaked = if snake then camelTo2 '_' else id


### PR DESCRIPTION
1. Unwrapping unary records by default was a hacky workaround when introducing this code cause Air API had a lot of types derived that way. But it is actually a poor default cause it breaks encoding if constructors are added. There are `deriving newtype` and `deriving via` options for cases when one indeed wants unwrapping. Yeah it is a breaking change, but it is not too late to do and we have compaREST to catch this.
2. omitNothingFields may be useful sometimes. I personally prefer preserving null fields as it serves as sort of documentation what else could be placed in the body, but sometimes we may want to drop simply to decrease payload size.