### PR TITLE
Generalize deriving arbitrary for types with parameters

### DIFF
--- a/derive-api-th.cabal
+++ b/derive-api-th.cabal
@@ -37,7 +37,8 @@ library
         openapi3
   default-language: Haskell2010
   default-extensions:
-      DuplicateRecordFields
+      BlockArguments
+    , DuplicateRecordFields
     , NamedFieldPuns
     , RecordWildCards
     , StandaloneDeriving

--- a/src/Derive/API/TH.hs
+++ b/src/Derive/API/TH.hs
@@ -26,7 +26,6 @@ import Data.Aeson.TH as A
 import Data.Aeson.Types
 import Data.List
 import Data.Maybe
--- import Data.Traversable
 import Data.Typeable
 import Language.Haskell.TH
 import Language.Haskell.TH.Datatype
@@ -131,8 +130,12 @@ datatypeVarsTypes = datatypeVars
 deriveArbitrary :: Name -> Q [Dec]
 deriveArbitrary t = do 
   tinfo <- reifyDatatype t
-  let ctx = AppT (ConT ''Arbitrary) <$> datatypeVarsTypes tinfo
-  pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` datatypeType tinfo)
+  let 
+    typ = datatypeType tinfo
+    ctx = datatypeVarsTypes tinfo >>= \tv -> 
+      [ ConT ''Arbitrary `AppT` tv
+      , ConT ''Arg `AppT` typ `AppT` tv  ]
+  pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` typ)
     [ FunD 'arbitrary [Clause [] (NormalB $ VarE 'genericArbitrary) []]
     , FunD 'shrink [Clause [] (NormalB $ VarE 'genericShrink) []] ] ]
 #endif

--- a/src/Derive/API/TH.hs
+++ b/src/Derive/API/TH.hs
@@ -152,8 +152,8 @@ deriveArbitrary t = do
     ba = VarE 'genericArbitrary
     bs = VarE 'genericShrink
   pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` datatypeType tinfo)
-    [ pure $ FunD 'arbitrary [Clause [] (NormalB ba) []]
-    , pure $ FunD 'shrink [Clause [] (NormalB bs) []] ]
+    [ FunD 'arbitrary [Clause [] (NormalB ba) []]
+    , FunD 'shrink [Clause [] (NormalB bs) []] ] ]
   --   (pure )
   --   (pure $ ConT ''ToSchema `AppT` datatypeType tinfo)
   --   [ funD 'declareNamedSchema $ pure $ clause [] (normalB body) [] ]

--- a/src/Derive/API/TH.hs
+++ b/src/Derive/API/TH.hs
@@ -149,5 +149,19 @@ deriveArbitrary t = do
     tvars = datatypeVars tinfo
 #endif
     ctx = AppT (ConT ''Arbitrary) <$> tvars
-  decs <- [d| arbitrary = genericArbitrary; shrink = genericShrink |]
-  pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` datatypeType tinfo) decs]
+    ba = VarE 'genericArbitrary
+    bs = VarE 'genericShrink
+  pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` datatypeType tinfo)
+    [ pure $ FunD 'arbitrary [Clause [] (NormalB ba) []]
+    , pure $ FunD 'shrink [Clause [] (NormalB bs) []] ]
+  --   (pure )
+  --   (pure $ ConT ''ToSchema `AppT` datatypeType tinfo)
+  --   [ funD 'declareNamedSchema $ pure $ clause [] (normalB body) [] ]
+  -- --   body = AppE (VarE 'genericDeclareNamedSchema) <$>
+  -- --     appE (pure $ VarE 'derivingOptionsToSchemaOptions) (lift opts)
+  -- -- pure <$> instanceD
+  -- --   (pure context)
+  -- --   (pure $ ConT ''ToSchema `AppT` datatypeType tinfo)
+  -- --   [ funD 'declareNamedSchema $ pure $ clause [] (normalB body) [] ]
+  -- decs <- [d| arbitrary = genericArbitrary; shrink = genericShrink |]
+  -- pure [InstanceD Nothing ctx (ConT ''Arbitrary `AppT` datatypeType tinfo) decs]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-19.16
+resolver: lts-22.27
+# resolver: lts-19.16
 # resolver: lts-18.6
 
 packages:


### PR DESCRIPTION
Currently we can't use `deriveApiAndArbitraryInstances` for parametrized types.
`deriveApiInstances` is working. The problem exists with `Arbitrary` instance.

In this PR I generalize TH-generation for Arbitrary instance.