### PR TITLE
Dependency fixes

### DIFF
--- a/derive-api-th.cabal
+++ b/derive-api-th.cabal
@@ -31,7 +31,7 @@ library
 
   if !(impl(ghcjs) || arch(javascript))
     build-depends:
-        generic-arbitrary
+        generic-arbitrary  >=1.0
       , openapi3
       , QuickCheck
 

--- a/derive-api-th.cabal
+++ b/derive-api-th.cabal
@@ -1,47 +1,47 @@
-cabal-version: 1.12
+cabal-version:      1.12
+name:               derive-api-th
+version:            0.1.0.0
+description:
+  Please see the README on GitHub at <https://github.com/typeable/derive-api-th#readme>
 
-name:           derive-api-th
-version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/typeable/derive-api-th#readme>
-homepage:       https://github.com/typeable/derive-api-th#readme
-bug-reports:    https://github.com/typeable/derive-api-th/issues
-author:         Typeable
-maintainer:     dima@typeable.io
-copyright:      2022 Typeable LLC
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-extra-source-files:
-    README.md
+homepage:           https://github.com/typeable/derive-api-th#readme
+bug-reports:        https://github.com/typeable/derive-api-th/issues
+author:             Typeable
+maintainer:         dima@typeable.io
+copyright:          2022 Typeable LLC
+license:            BSD3
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/typeable/derive-api-th
 
 library
-  exposed-modules:
-      Derive.API.TH
-  other-modules:
-      Paths_derive_api_th
-  hs-source-dirs:
-      src
+  exposed-modules:    Derive.API.TH
+  other-modules:      Paths_derive_api_th
+  hs-source-dirs:     src
   build-depends:
-      base >=4.7 && <5
-    , aeson
+      aeson
+    , base              >=4.7 && <5
     , containers
     , template-haskell
     , th-abstraction
+
   if !(impl(ghcjs) || arch(javascript))
     build-depends:
-        openapi3
-      , generic-arbitrary
+        generic-arbitrary
+      , openapi3
       , QuickCheck
-    cpp-options: -DBACKEND
-  default-language: Haskell2010
+
+    cpp-options:   -DBACKEND
+
+  default-language:   Haskell2010
   default-extensions:
-      BlockArguments
-    , DuplicateRecordFields
-    , NamedFieldPuns
-    , RecordWildCards
-    , StandaloneDeriving
-    , TemplateHaskell
+    BlockArguments
+    DuplicateRecordFields
+    NamedFieldPuns
+    RecordWildCards
+    StandaloneDeriving
+    TemplateHaskell

--- a/src/Derive/API/TH.hs
+++ b/src/Derive/API/TH.hs
@@ -61,9 +61,13 @@ deriveApiAndArbitraryInstances opts tname =
 #endif
 
 #if MIN_VERSION_containers(0,6,6)
-#elif MIN_VERSION_template_haskell(2,16,0)
+#elif MIN_VERSION_template_haskell(2,17,0)
 instance (Lift k, Lift a) => Lift (Map k a) where
   liftTyped x = unsafeCodeCoerce (lift x)
+  lift m = [|M.fromList (M.toList m)|]
+#elif MIN_VERSION_template_haskell(2,16,0)
+instance (Lift k, Lift a) => Lift (Map k a) where
+  liftTyped x = unsafeTExpCoerce (lift x)
   lift m = [|M.fromList (M.toList m)|]
 #else
 instance (Lift k, Lift a) => Lift (Map k a) where


### PR DESCRIPTION
- `base >=4.12` (GHC >=8.6) because older GHC don't support BlockArguments
- `generic-arbitrary >=1.0` because that's when `Arg` was introduced
- Fixed up ifdefs relating to `liftTyped` being introduced in `template-haskell-2.16` (GHC 8.10) and then being changed in `template-haskell-2.17` (GHC 9.0)